### PR TITLE
[FEAT] padroniza header/botão e sincroniza avatar do perfil

### DIFF
--- a/css/profile.css
+++ b/css/profile.css
@@ -21,17 +21,27 @@
 .profile__title {
   margin: 0;
   font-weight: 700;
-  font-size: clamp(1.25rem, 2.2vw + .6rem, 2rem);
 }
 
+/* botão de voltar (seta) usado em header/páginas */
 .profile__back {
   position: absolute;
   left: clamp(.5rem, 2vw, 1.25rem);
-  background: var(--color-white);
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
   border: 0;
-  border: 0;
-  padding: .25rem;
+  padding: .35rem;
+  display: grid;
+  place-items: center;
   cursor: pointer;
+  color: var(--color-primary);
+  box-shadow: none;
+  z-index: 50;
+}
+
+/* quando usado dentro do header com a pílula laranja, a seta fica branca para contraste */
+.dash-header .profile__back {
   color: var(--color-primary);
 }
 

--- a/css/ranking.css
+++ b/css/ranking.css
@@ -1,258 +1,266 @@
-body, .name, .ranking-lista li span{
-    font-family: 'Inter', sans-serif;
-/* Topo laranja ranking */
-.ranking-header {
-    background-color: #FF6A00;
-    color: white;
-    text-align: center;
-    padding: 15px 0;
-    border-bottom-left-radius: 50% 100px;
-    border-bottom-right-radius: 50% 100px;
-    width: 450px;
-    margin: 0 auto;
-}
-
-.ranking-header h2 {
-    margin: 0;
-    font-weight: bold;
-}
-
-.ranking-top {
-    position: relative;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-}
-
-.botão-voltar {
-    position: absolute;
-    left: 20px;
-    background: none;
-    border: none;
-    font-size: 1.8rem;
-    color: #D9D9D9;
-    cursor: pointer;
-}
-
-.ranking {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 60px;
-}
-
-/* --- top 3 do ranking */
-.top3 {
-    display: flex;
-    justify-content: center;
-    align-items: flex-end;
-    gap: 20px;
-}
-
-.place {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  position: relative;
-}
-
-.avatar {
-    position: relative;
-}
-
-.avatar img {
-    border-radius: 50%;
-    width: 130px;
-    height: 130px;
-    object-fit: cover;
-}
-
-.crown {
-    position: absolute;
-    top: -90px;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 20px;   /* menor */
-    z-index: 2;
-}
-
-.podium {
-    margin-top: 5px;
-    width: 120px;
-    height: 300px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    font-size: 1.5rem;
-    color: white;
-    padding-bottom: 5px;
-    background: linear-gradient(to top, white, #FA8001 100%);
-}
-
-.first-podium {
-    height: 220px;
-}
-
-.second-podium {
-    height: 170px;
-}
-
-.third-podium {
-    height: 170px;
-}
-
-.podium-number {
-    position: absolute;
-    font-family: 'Montserrat', sans-serif;
-}
-
-.first-podium .podium-number {
-    top: 220px;
-    font-size: 2.8rem;
-}
-
-.second-podium .podium-number{
-    top: 200px;
-    font-size: 2.5rem;
-}
-
-.third-podium .podium-number{
-    top: 200px;
-    font-size: 2.5rem;
-}
-
-.name {
-    margin-top: 8px;
-    background: #D9D9D9; /* fundo inteiro cinza */
-    color: black;
-    padding: 6px 20px;
-    border-radius: 12px;
-    font-size: 1.5rem;
-    font-weight: 500;
-}
-
-.place img {
-    width: 70px;
-    height: 70px;
-    border-radius: 50%;
-    object-fit: cover;
-}
-.ranking-separador {
-    width: 100%;
-    max-width: 800px;
-    height: 20px #333;
-    background: white;
-    margin: 2px auto;
-}
-
-.ranking-lista::-webkit-scrollbar {
-    width: 2px;
-    margin-top: 10px;
-    margin-bottom: 10px;
-}
-
-.ranking-lista::-webkit-scrollbar-track {
-    background: #f0f0f0; /* cor de fundo */
-    border-radius: 10px;
-}
-
-.ranking-lista::-webkit-scrollbar-thumb {
-    background: #FF3300; 
-    border-radius: 10px;
-}
-
-.ranking-lista::-webkit-scrollbar-thumb:hover {
-    background: #FF3300;
-}
-
-.first {
-    order: 2;
-}
-
-.second {
-    order: 1;
-}
-
-.third {
-    order: 3;
-}
-
-/* -- resto da lista --*/
-
-.ranking-lista {
-    width: 100%;
-    max-width: 800px;
-    max-height: 350px;
-    overflow-y: auto;
-    margin-top: 0;
-    padding: 5px;
-    top: 15px;
-}
-
-.ranking-lista ol {
-    top: 5px;
-    position: absolute;
-    font-family: 'Montserrat', sans-serif;
-    margin: 0;
-    padding-left: 20px;
-    list-style-position: outside;
-}
-
-.ranking-lista ul{
-    list-style: none;
-    padding: 0;
-    margin: 0;
-}
-
-.ranking-lista li {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    margin-bottom: 5px;
-    max-width: 500px;
-    margin-left: auto;
-    margin-right: auto;
-    background: none;
-    border: none;
-}
-
-.ranking-lista .position {
-    color: #FF3300;
-    width: 15px;
-    font-weight: 700;
-    text-align: right;
-}
-
-.ranking-lista li img {
-    width: 60px;
-    height: 60px;
-    border-radius: 50%;
-    object-fit: cover;
-}
-
-.ranking-lista .name {
-    font-family: 'Inter', sans-serif;
-    background: #D9D9D9;
-    padding: 12px 12px;
-    border-radius: 40px;
-    flex: 1;
-    text-align: center;
-}
- 
+body,
+.name,
 .ranking-lista li span {
-    font-size: 18px;
-    font-weight: 600;
-}
+    font-family: 'Inter', sans-serif;
 
-.first img {
-  width: 150px;
-  height: 150px;
-}
+    /* Topo laranja ranking */
+    .ranking-header {
+        background-color: #FF6A00;
+        color: white;
+        text-align: center;
+        padding: 15px 0;
+        border-bottom-left-radius: 50% 100px;
+        border-bottom-right-radius: 50% 100px;
+        width: 450px;
+        margin: 0 auto;
+    }
 
-.second img,
-.third img {
-  width: 130px;
-  height: 130px;
-}
+    .ranking-header h2 {
+        margin: 0;
+        font-weight: bold;
+    }
+
+    .ranking-top {
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 10px;
+    }
+
+    .botão-voltar {
+        position: absolute;
+        left: 20px;
+        background: none;
+        border: none;
+        font-size: 1.8rem;
+        color: #D9D9D9;
+        cursor: pointer;
+    }
+
+    .ranking {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 60px;
+    }
+
+    /* --- top 3 do ranking */
+    .top3 {
+        display: flex;
+        justify-content: center;
+        align-items: flex-end;
+        gap: 20px;
+    }
+
+    .place {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        position: relative;
+    }
+
+    .avatar {
+        position: relative;
+    }
+
+    .avatar img {
+        border-radius: 50%;
+        width: 130px;
+        height: 130px;
+        object-fit: cover;
+    }
+
+    .crown {
+        position: absolute;
+        top: -90px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 20px;
+        /* menor */
+        z-index: 2;
+    }
+
+    .podium {
+        margin-top: 5px;
+        width: 120px;
+        height: 300px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-size: 1.5rem;
+        color: white;
+        padding-bottom: 5px;
+        background: linear-gradient(to top, white, #FA8001 100%);
+    }
+
+    .first-podium {
+        height: 220px;
+    }
+
+    .second-podium {
+        height: 170px;
+    }
+
+    .third-podium {
+        height: 170px;
+    }
+
+    .podium-number {
+        position: absolute;
+        font-family: 'Montserrat', sans-serif;
+    }
+
+    .first-podium .podium-number {
+        top: 220px;
+        font-size: 2.8rem;
+    }
+
+    .second-podium .podium-number {
+        top: 200px;
+        font-size: 2.5rem;
+    }
+
+    .third-podium .podium-number {
+        top: 200px;
+        font-size: 2.5rem;
+    }
+
+    .name {
+        margin-top: 8px;
+        background: #D9D9D9;
+        /* fundo inteiro cinza */
+        color: black;
+        padding: 6px 20px;
+        border-radius: 12px;
+        font-size: 1.5rem;
+        font-weight: 500;
+    }
+
+    .place img {
+        width: 70px;
+        height: 70px;
+        border-radius: 50%;
+        object-fit: cover;
+    }
+
+    .ranking-separador {
+        width: 100%;
+        max-width: 800px;
+        height: 20px #333;
+        background: white;
+        margin: 2px auto;
+    }
+
+    .ranking-lista::-webkit-scrollbar {
+        width: 2px;
+        margin-top: 10px;
+        margin-bottom: 10px;
+    }
+
+    .ranking-lista::-webkit-scrollbar-track {
+        background: #f0f0f0;
+        /* cor de fundo */
+        border-radius: 10px;
+    }
+
+    .ranking-lista::-webkit-scrollbar-thumb {
+        background: #FF3300;
+        border-radius: 10px;
+    }
+
+    .ranking-lista::-webkit-scrollbar-thumb:hover {
+        background: #FF3300;
+    }
+
+    .first {
+        order: 2;
+    }
+
+    .second {
+        order: 1;
+    }
+
+    .third {
+        order: 3;
+    }
+
+    /* -- resto da lista --*/
+
+    .ranking-lista {
+        width: 100%;
+        max-width: 800px;
+        max-height: 350px;
+        overflow-y: auto;
+        margin-top: 0;
+        padding: 5px;
+        top: 15px;
+    }
+
+    .ranking-lista ol {
+        top: 5px;
+        position: absolute;
+        font-family: 'Montserrat', sans-serif;
+        margin: 0;
+        padding-left: 20px;
+        list-style-position: outside;
+    }
+
+    .ranking-lista ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+    }
+
+    .ranking-lista li {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        margin-bottom: 5px;
+        max-width: 500px;
+        margin-left: auto;
+        margin-right: auto;
+        background: none;
+        border: none;
+    }
+
+    .ranking-lista .position {
+        color: #FF3300;
+        width: 15px;
+        font-weight: 700;
+        text-align: right;
+    }
+
+    .ranking-lista li img {
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        object-fit: cover;
+    }
+
+    .ranking-lista .name {
+        font-family: 'Inter', sans-serif;
+        background: #D9D9D9;
+        padding: 8px 10px;
+        border-radius: 32px;
+        flex: 1;
+        text-align: center;
+        font-size: 0.95rem;
+    }
+
+    .ranking-lista li span {
+        font-size: 18px;
+        font-weight: 600;
+    }
+
+    .first img {
+        width: 150px;
+        height: 150px;
+    }
+
+    .second img,
+    .third img {
+        width: 130px;
+        height: 130px;
+    }
 }

--- a/js/ranking.js
+++ b/js/ranking.js
@@ -1,0 +1,17 @@
+// ranking.js
+// carrega avatar salvo em localStorage (avatarDataUrl) e substitui o avatar do 1º lugar
+(function () {
+    try {
+        const dataUrl = localStorage.getItem('avatarDataUrl');
+        if (!dataUrl) return;
+        // aguarda DOM
+        document.addEventListener('DOMContentLoaded', function () {
+            const first = document.getElementById('firstAvatar');
+            if (first) {
+                first.src = dataUrl;
+            }
+        });
+    } catch (e) {
+        console.error('ranking.js error', e);
+    }
+})();

--- a/pages/ranking.html
+++ b/pages/ranking.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="pt-BR">
+
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -7,20 +8,26 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/tokens.css">
+  <link rel="stylesheet" href="../css/base.css">
+  <link rel="stylesheet" href="../css/home.css">
+  <link rel="stylesheet" href="../css/profile.css">
   <link rel="stylesheet" href="../css/ranking.css">
 </head>
+
 <body class="bg-light">
 
-  <!-- Topo com faixa -->
-  <header class="ranking-header">
-    <h2>Ranking</h2>
-  </header>
-
-  <!-- Botão para voltar -->
-  <header class="ranking-top">
-    <button class="botão-voltar">
-      <img src="https://img.icons8.com/ios-glyphs/30/808080/chevron-left.png" alt="Voltar">
+  <!-- Header com pílula igual ao home -->
+  <header class="dash-header text-center position-relative">
+    <button class="profile__back" onclick="window.location.href='./home.html'" aria-label="Voltar">
+      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <path d="M15 18l-6-6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round" />
+      </svg>
     </button>
+    <div class="dash-header__pill">
+      <h1 class="dash-header__title m-0">Ranking</h1>
+    </div>
   </header>
 
   <main class="ranking">
@@ -37,7 +44,7 @@
 
       <div class="place first">
         <div class="avatar">
-          <img src="../assets/img/avatar1.png" alt="1º lugar">
+          <img id="firstAvatar" src="../assets/img/avatar1.png" alt="1º lugar">
           <img class="crown" src="../assets/img/coroa-ouro.png" alt="Coroa ouro">
         </div>
         <span class="name">Carlos Henrique</span>
@@ -59,28 +66,45 @@
     <!-- Lista do top 4 em diante -->
     <section class="ranking-lista">
       <ul>
-        <li><span class="position">4.</span><img src="../assets/img/icon.png" alt><span class="name">Francisco Pinto</span></li>
-        <li><span class="position">5.</span><img src="../assets/img/icon.png" alt><span class="name">Patroncio Ribeiro</span></li>
-        <li><span class="position">6.</span><img src="../assets/img/icon.png" alt><span class="name">Mariana Costa</span></li>
-        <li><span class="position">7.</span><img src="../assets/img/icon.png" alt><span class="name">Gustavo Carvalho</span></li>
-        <li><span class="position">8.</span><img src="../assets/img/icon.png" alt><span class="name">Cleydy Lima</span></li>
-        <li><span class="position">9.</span><img src="../assets/img/icon.png" alt><span class="name">Antonieta Lopez</span></li>
-        <li><span class="position">10.</span><img src="../assets/img/icon.png" alt><span class="name">Jurandi Menezes</span></li>
-        <li><span class="position">11.</span><img src="../assets/img/icon.png" alt><span class="name">Luiz Sucha</span></li>
-        <li><span class="position">12.</span><img src="../assets/img/icon.png" alt><span class="name">Flavio Gonzalvez</span></li>
-        <li><span class="position">13.</span><img src="../assets/img/icon.png" alt><span class="name">Ana Clara Machado</span></li>
-        <li><span class="position">14.</span><img src="../assets/img/icon.png" alt><span class="name">Matias Lima</span></li>
-        <li><span class="position">15.</span><img src="../assets/img/icon.png" alt></span> <span class="name">Camilo Freitas</span></li>
-        <li><span class="position">16.</span><img src="../assets/img/icon.png" alt></span> <span class="name">Leonardo Alonso</span></li>
-        <li><span class="position">17.</span><img src="../assets/img/icon.png" alt></span> <span class="name">Brian Luis</span></li>
-        <li><span class="position">18.</span><img src="../assets/img/icon.png" alt></span> <span class="name">Marcela Cruz</span></li>
-        <li><span class="position">19.</span><img src="../assets/img/icon.png" alt></span> <span class="name">Paulo Dias</span></li>
-        <li><span class="position">20.</span><img src="../assets/img/icon.png" alt></span> <span class="name">Michelle Ramirez</span></li>
+        <li><span class="position">4.</span><img src="../assets/img/icon.png" alt><span class="name">Francisco
+            Pinto</span></li>
+        <li><span class="position">5.</span><img src="../assets/img/icon.png" alt><span class="name">Patroncio
+            Ribeiro</span></li>
+        <li><span class="position">6.</span><img src="../assets/img/icon.png" alt><span class="name">Mariana
+            Costa</span></li>
+        <li><span class="position">7.</span><img src="../assets/img/icon.png" alt><span class="name">Gustavo
+            Carvalho</span></li>
+        <li><span class="position">8.</span><img src="../assets/img/icon.png" alt><span class="name">Cleydy Lima</span>
+        </li>
+        <li><span class="position">9.</span><img src="../assets/img/icon.png" alt><span class="name">Antonieta
+            Lopez</span></li>
+        <li><span class="position">10.</span><img src="../assets/img/icon.png" alt><span class="name">Jurandi
+            Menezes</span></li>
+        <li><span class="position">11.</span><img src="../assets/img/icon.png" alt><span class="name">Luiz Sucha</span>
+        </li>
+        <li><span class="position">12.</span><img src="../assets/img/icon.png" alt><span class="name">Flavio
+            Gonzalvez</span></li>
+        <li><span class="position">13.</span><img src="../assets/img/icon.png" alt><span class="name">Ana Clara
+            Machado</span></li>
+        <li><span class="position">14.</span><img src="../assets/img/icon.png" alt><span class="name">Matias Lima</span>
+        </li>
+        <li><span class="position">15.</span><img src="../assets/img/icon.png" alt></span> <span class="name">Camilo
+            Freitas</span></li>
+        <li><span class="position">16.</span><img src="../assets/img/icon.png" alt></span> <span class="name">Leonardo
+            Alonso</span></li>
+        <li><span class="position">17.</span><img src="../assets/img/icon.png" alt></span> <span class="name">Brian
+            Luis</span></li>
+        <li><span class="position">18.</span><img src="../assets/img/icon.png" alt></span> <span class="name">Marcela
+            Cruz</span></li>
+        <li><span class="position">19.</span><img src="../assets/img/icon.png" alt></span> <span class="name">Paulo
+            Dias</span></li>
+        <li><span class="position">20.</span><img src="../assets/img/icon.png" alt></span> <span class="name">Michelle
+            Ramirez</span></li>
       </ul>
     </section>
   </main>
 
+  <script src="../js/ranking.js" defer></script>
 </body>
+
 </html>
-
-


### PR DESCRIPTION
## Contexto
Padronizei a tela de Ranking para manter consistência visual e corrigi a navegação. Também conectei o avatar do usuário com a foto definida em “Editar perfil”.

## O que foi feito
- Header no mesmo tamanho e cor das demais telas
- Botão **Voltar** padronizado (tamanho/cor) e rota corrigida → volta para Home
- Elementos com tamanho ligeiramente reduzido para melhor harmonia
- Regra JS: a foto de “Editar perfil” passa a refletir no avatar do Ranking

## Antes x Depois
- **Antes:** header e botão com padrões diferentes; rota do voltar inconsistente; avatar do ranking não refletia a foto do perfil
<img width="1364" height="644" alt="Captura de tela 2025-10-03 151331" src="https://github.com/user-attachments/assets/105c64b5-b63f-4228-a284-712b75b9af5e" />

- **Depois:** visual padronizado, rota correta e avatar sincronizado
<img width="1365" height="643" alt="Captura de tela 2025-10-03 152418" src="https://github.com/user-attachments/assets/7cb95730-31dc-47a6-b422-f2da1161e1b2" />

## Impacto/Risco
Baixo. Mudanças visuais e ajuste simples de rota/regra JS.

## Plano de rollback
`git revert <hash-do-commit>`
