### PR TITLE
[FEAT] padroniza header/voltar, animação leve e perguntas Swift

### DIFF
--- a/css/fleshcard.css
+++ b/css/fleshcard.css
@@ -1,159 +1,215 @@
-:root{
-  --orange:#ff7a00;
-  --soft:#ffd9c6;
-  --bg:#fff8f3;
-  --accent:#ff6a00;
+:root {
+  --orange: #ff7a00;
+  --soft: #ffd9c6;
+  --bg: #fff8f3;
+  --accent: #ff6a00;
 }
 
-*{box-sizing:border-box}
-body{
-  background: linear-gradient(180deg, #fff8f3 0%, #fff2ea 60%);
+* {
+  box-sizing: border-box
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  /* usar o fundo branco padrão das outras páginas */
+  background: var(--color-white, #ffffff);
   font-family: "Segoe UI", Roboto, "Helvetica Neue", Arial;
-  color:#333;
-  min-height:100vh;
-  margin:0;
+  color: #333;
+  min-height: 100%;
+  margin: 0;
+  /* remover rolagem da página inteira para a tela de flashcards */
+  overflow: hidden;
 }
 
 /* botão achatado (oval “squashed”) */
 .title-wrap {
   margin-top: 10px;
-  text-align: center; /* centra na tela */
+  text-align: center;
+  /* centra na tela */
 }
 
 .title {
-   background-color: #FF6A00;
-    color: white;
-    text-align: center;
-    padding: 15px 0;
-    border-bottom-left-radius: 50% 100px;
-    border-bottom-right-radius: 50% 100px;
-    width: 450px;
-    margin: 0 auto;
+  background-color: #FF6A00;
+  color: white;
+  text-align: center;
+  padding: 15px 0;
+  border-bottom-left-radius: 50% 100px;
+  border-bottom-right-radius: 50% 100px;
+  width: 450px;
+  margin: 0 auto;
 }
+
 /* cena do cartão */
-.flashcard-scene{
-  width: 320px;
-  height: 480px;
-  position:relative;
-  margin-top:12px;
+.flashcard-scene {
+  /* tornar a cena responsiva e caber na viewport sem causar scroll da página */
+  width: min(420px, 92vw);
+  height: min(560px, 65vh);
+  position: relative;
+  margin-top: 0;
+  z-index: 2;
+}
+
+/* container principal: ocupar viewport restante abaixo do header */
+main.container {
+  height: calc(100vh - 100px);
+  /* considera header ~80px + espaçamento */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  /* garantir espaço abaixo do header/pílula para não cobrir o cartão */
+  padding-top: 80px;
+  padding-bottom: 0;
 }
 
 /* setas laterais */
-.nav-arrow{
-  position:absolute;
-  top:50%;
-  transform:translateY(-50%);
-  font-size:26px;
-  color:var(--orange);
-  user-select:none;
-  cursor:pointer;
-  width:36px;
-  height:36px;
-  display:flex;
-  align-items:center;
-  justify-content:center;
+.nav-arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 26px;
+  color: var(--orange);
+  user-select: none;
+  cursor: pointer;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
-.nav-left{ left:-48px; }
-.nav-right{ right:-48px; }
+
+.nav-left {
+  left: -48px;
+}
+
+.nav-right {
+  right: -48px;
+}
 
 /* cartão principal */
-.flashcard{
-  width:100%;
-  height:100%;
-  background:white;
-  border-radius:18px;
-  border:2px solid var(--orange);
-  box-shadow: 0 6px 20px rgba(255,122,0,0.08);
-  position:absolute;
-  left:0;
-  top:0;
-  display:flex;
-  flex-direction:column;
-  align-items:center;
-  justify-content:flex-start;
-  padding:10px 12px 18px;
-  transition:transform 300ms ease, opacity 300ms ease;
-  touch-action:none; /* pointer events touch */
+.flashcard {
+  width: 100%;
+  height: 100%;
+  background: white;
+  border-radius: 18px;
+  border: 2px solid var(--orange);
+  box-shadow: 0 6px 20px rgba(255, 122, 0, 0.08);
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 3;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 12px 10px 12px;
+  transition: transform 300ms ease, opacity 300ms ease;
+  touch-action: none;
+  /* pointer events touch */
+  overflow: hidden;
 }
 
 /* cartão de trás (efeito pilha) */
-.flashcard.back{
+.flashcard.back {
   transform: translateY(18px);
-  left:8px;
+  left: 8px;
   width: calc(100% - 8px);
   height: calc(100% - 8px);
-  border-radius:18px;
-  border:1px solid rgba(255,122,0,0.15);
-  background: linear-gradient(180deg, rgba(255,240,230,0.8), rgba(255,245,240,0.7));
-  z-index:0;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 122, 0, 0.08);
+  /* reduzir intensidade para evitar película/cobertura do cartão principal */
+  background: linear-gradient(180deg, rgba(255, 245, 240, 0.24), rgba(255, 245, 240, 0.12));
+  z-index: 1;
 }
 
 /* botão fechar (x) */
-.btn-close{
+.btn-close {
   background: none;
   border: none;
-  width:28px;
-  height:28px;
-  color:#bfbfbf;
+  width: 28px;
+  height: 28px;
+  color: #bfbfbf;
 }
 
 /* imagem do cartão */
-.card-image{
-  width:76%;
-  height:120px;
-  margin-top:6px;
-  border-radius:8px;
-  background:var(--soft);
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  color:var(--orange);
-  font-weight:600;
+.card-image {
+  width: 70%;
+  height: 88px;
+  margin-top: 6px;
+  border-radius: 8px;
+  background: var(--soft);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--orange);
+  font-weight: 600;
 }
 
 /* pergunta */
 .question {
-  margin-top: 8px;
-  margin-bottom: 12px; 
+  margin: 6px 0 8px;
   color: var(--orange);
-  font-size: 18px;
-  font-weight: 500;
+  font-size: 16px;
+  font-weight: 600;
   text-align: center;
 }
 
 /* respostas */
-.answers{ margin-top: 12px;
-  gap: 10px;
-  position: absolute;
-  left: 10px;
-  bottom: 20px;
+.answers {
+  margin-top: 10px;
+  gap: 8px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  margin-bottom: 6px;
 }
-.answer-btn{
-  width:42px;
-  height:42px;
-  border-radius:50%;
-  border:none;
-  margin:8px 0;
-  background:var(--orange);
-  color:white;
-  font-weight:700;
-  display:inline-flex;
-  align-items:center;
-  justify-content:center;
-  cursor:pointer;
-  user-select:none;
+
+.answer-btn {
+  width: 86%;
+  max-width: 300px;
+  height: 40px;
+  border-radius: 8px;
+  border: none;
+  margin: 6px 0;
+  background: var(--orange);
+  color: white;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
 }
 
 /* progresso */
-.progress-wrap .progress-box{
-  background: linear-gradient(180deg, rgba(255,140,30,0.18), rgba(255,120,40,0.12));
-  border-radius:12px;
-  box-shadow: 0 6px 20px rgba(255,120,0,0.06);
+.progress-wrap .progress-box {
+  background: linear-gradient(180deg, rgba(255, 140, 30, 0.18), rgba(255, 120, 40, 0.12));
+  border-radius: 12px;
+  box-shadow: 0 6px 20px rgba(255, 120, 0, 0.06);
 }
-.progress-percent{
-  font-size:24px;
-  color:white;
-  text-shadow: 0 1px 0 rgba(0,0,0,0.08);
+
+.progress-percent {
+  font-size: 24px;
+  color: white;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
 }
-.progress{ height:10px; background:rgba(255,255,255,0.6); border-radius:10px; overflow:hidden; }
-.progress-bar{ background: linear-gradient(90deg, var(--orange), var(--accent)); height:100%; transition:width 300ms ease; }
+
+.progress {
+  height: 10px;
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.progress-bar {
+  background: linear-gradient(90deg, var(--orange), var(--accent));
+  height: 100%;
+  transition: width 300ms ease;
+}

--- a/js/fleshcard.js
+++ b/js/fleshcard.js
@@ -13,10 +13,10 @@ let cardsIndex = 0;
 
 // deck de exemplo 
 const deck = [
-  { imgText: 'Imagem 1', question: 'Qual é a cor do céu?', answers: ['A', 'B', 'C', 'D'] },
-  { imgText: 'Imagem 2', question: 'Quantos pés tem um cachorro?', answers: ['A', 'B', 'C', 'D'] },
-  { imgText: 'Imagem 3', question: 'Quem descobriu o Brasil?', answers: ['A', 'B', 'C', 'D'] },
-  { imgText: 'Imagem 4', question: 'Qual é 2 + 2?', answers: ['A', 'B', 'C', 'D'] }
+  { imgText: 'Imagem 1', question: 'Qual é o nome do fundador da Swift e o que ele inovou na indústria de carnes?', answers: ['A', 'B', 'C', 'D'] },
+  { imgText: 'Imagem 2', question: 'Onde foi inaugurada a primeira loja sustentável da Swift e o que a torna especial?', answers: ['A', 'B', 'C', 'D'] },
+  { imgText: 'Imagem 3', question: 'Quantos pontos de venda a Swift possui atualmente no Brasil?', answers: ['A', 'B', 'C', 'D'] },
+  { imgText: 'Imagem 4', question: 'Qual é o principal objetivo da Swift em relação à experiência de compra do cliente?', answers: ['A', 'B', 'C', 'D'] }
 ];
 
 function loadCard(idx){

--- a/pages/fleshcard.html
+++ b/pages/fleshcard.html
@@ -1,51 +1,61 @@
 <!DOCTYPE html>
 <html lang="pt-br">
+
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>FlashCard</title>
 
-  
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
 
-  
-  <link rel="stylesheet" href="../css/fleshcard.css" />
 </head>
-<body>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+<link rel="stylesheet" href="../css/tokens.css" />
+<link rel="stylesheet" href="../css/base.css" />
+<link rel="stylesheet" href="../css/home.css" />
+<link rel="stylesheet" href="../css/profile.css" />
+<link rel="stylesheet" href="../css/fleshcard.css" />
+</head>
 
-  <header class="title-wrap text-center">
-    <div class="title-wrap">
-   <div class="title">FlashCard</div>
-   </div>
+<body>
+  <header class="dash-header text-center position-relative">
+    <button class="profile__back" onclick="window.location.href='./home.html'" aria-label="Voltar">
+      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <path d="M15 18l-6-6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round" />
+      </svg>
+    </button>
+    <div class="dash-header__pill">
+      <h1 class="dash-header__title m-0">FlashCard</h1>
+    </div>
   </header>
 
   <main class="container d-flex flex-column align-items-center justify-content-center mt-3">
     <div class="flashcard-scene position-relative">
       <div class="nav-arrow nav-left" id="prevBtn" aria-hidden="true">&lt;</div>
 
-      
-        <div class="flashcard" id="flashcard" role="button" aria-label="Cartão de pergunta">
-         <button class="btn-close align-self-start ms-2 mt-2" aria-label="fechar"></button>
 
-           <div class="question text-center text-orange" id="cardQuestion">Pergunta</div>
+      <div class="flashcard" id="flashcard" role="button" aria-label="Cartão de pergunta">
+        <button class="btn-close align-self-start ms-2 mt-2" aria-label="fechar"></button>
 
-           <div class="card-image mx-auto mt-2" id="cardImage">Imagem</div>
+        <div class="question text-center text-orange" id="cardQuestion">Pergunta</div>
 
-            <div class="answers" id="cardAnswers">
-            <div><button class="answer-btn" data-key="A">A</button> <span>Alternativa 1</span></div>
-            <div><button class="answer-btn" data-key="B">B</button> <span>Alternativa 2</span></div>
-            <div><button class="answer-btn" data-key="C">C</button> <span>Alternativa 3</span></div>
-            <div><button class="answer-btn" data-key="D">D</button> <span>Alternativa 4</span></div>
+        <div class="card-image mx-auto mt-2" id="cardImage">Imagem</div>
+
+        <div class="answers" id="cardAnswers">
+          <div><button class="answer-btn" data-key="A">A</button> <span>Alternativa 1</span></div>
+          <div><button class="answer-btn" data-key="B">B</button> <span>Alternativa 2</span></div>
+          <div><button class="answer-btn" data-key="C">C</button> <span>Alternativa 3</span></div>
+          <div><button class="answer-btn" data-key="D">D</button> <span>Alternativa 4</span></div>
         </div>
-     </div>
+      </div>
 
-      
+
       <div class="flashcard back" id="backCard" aria-hidden="true"></div>
 
       <div class="nav-arrow nav-right" id="nextBtn" aria-hidden="true">&gt;</div>
     </div>
 
-    
+
     <div class="progress-wrap w-75 mt-4">
       <div class="progress-box p-3 rounded">
         <div class="progress-percent text-center fw-bold" id="progressText">50%</div>
@@ -56,7 +66,8 @@
     </div>
   </main>
 
-  
+
   <script src="../js/fleshcard.js"></script>
 </body>
+
 </html>

--- a/pages/home.html
+++ b/pages/home.html
@@ -81,8 +81,8 @@
                     class="bi bi-house-fill fs-5"></i></a>
             <a class="nav-link text-orange" href="./ranking.html" aria-label="Troféus"><i
                     class="bi bi-trophy-fill fs-5"></i></a>
-            <a class="nav-link text-orange" href="./flashcards.html" aria-label="Atividades"><i
-                    class="bi bi-grid-3x3-gap-fill fs-5"></i></a>
+            <a class="nav-link text-orange" href="./fleshcard.html" aria-label="Atividades"><i
+                    class="bi bi-question-circle-fill fs-5"></i></a>
             <a class="nav-link text-orange" href="./perfil.html" aria-label="Configurações"><i
                     class="bi bi-gear-fill fs-5"></i></a>
             <a class="nav-link text-orange" href="./profile.html" aria-label="Perfil"><i


### PR DESCRIPTION
## Contexto
Ajustei a tela de **Flashcards** para manter consistência visual/comportamental com o resto do app e deixei o fluxo mais intuitivo. Fiz também uma pequena melhoria no menu da **Home** para facilitar a descoberta da seção.

## O que foi feito
- **Flashcards**: header padronizado (tamanho, cor, fonte)
- **Flashcards**: botão **Voltar** para a Home, seguindo o padrão das outras páginas
- **Flashcards**: micro melhoria na animação dos cards
- **Flashcards**: adicionadas perguntas mais direcionadas a **Swift**
- **Home**: ícone do menu alterado para **interrogação** (melhor sinalização para dúvidas/flashcards)

## Impacto/Risco
Baixo — mudanças visuais, navegação simples e conteúdo dos cards.

## Rollback
`git revert <hash-do-commit>`
